### PR TITLE
Bug union

### DIFF
--- a/src/gibbon/workflows/transformations/union.py
+++ b/src/gibbon/workflows/transformations/union.py
@@ -16,15 +16,12 @@ class Union(ManyToMany):
                     break
 
                 for iq in self.in_queues:
-                    if eof_signals[iq] or iq.empty():
-                        continue
-
-                    row = await iq.get()
-
-                    if row is None:
-                        eof_signals[iq] = True
-                    else:
-                        for oq in self.out_queues:
-                            await oq.put(row)
+                    if not eof_signals[iq]:
+                        row = await iq.get()
+                        if row is None:
+                            eof_signals[iq] = True
+                        else:
+                            for oq in self.out_queues:
+                                await oq.put(row)
 
         return job

--- a/src/gibbon/workflows/transformations/union.py
+++ b/src/gibbon/workflows/transformations/union.py
@@ -6,24 +6,25 @@ class Union(ManyToMany):
         super().__init__(name, in_ports, out_ports)
 
     def get_async_job(self):
-        input_queues = [q for q in self.in_queues]
+        eof_signals = {q: False for q in self.in_queues}
 
         async def job():
             while True:
-                if len(input_queues) == 0:
+                if all(eof_signals.values()):
                     for oq in self.out_queues:
                         await oq.put(None)
                     break
 
-                for iq in input_queues:
-                    if iq.empty():
+                for iq in self.in_queues:
+                    if eof_signals[iq] or iq.empty():
                         continue
 
                     row = await iq.get()
 
                     if row is None:
-                        input_queues.remove(iq)
+                        eof_signals[iq] = True
                     else:
                         for oq in self.out_queues:
                             await oq.put(row)
+
         return job

--- a/tests/test_tfx_union.py
+++ b/tests/test_tfx_union.py
@@ -19,7 +19,6 @@ class TestUnionCreate(unittest.TestCase):
         self.assertTrue(self.w.is_valid)
 
 
-#@unittest.skip  # causes the test harness to hang in the all_tests scenario
 class TestUnionRun(unittest.TestCase):
     def setUp(self):
         self.w = gibbon.Workflow('test_union')
@@ -51,9 +50,6 @@ class TestUnionRun(unittest.TestCase):
         self.assertSequenceEqual(sorted(list(dict_for_assert.keys())), sorted(list(ref_for_assert.keys())))
         self.assertSequenceEqual(sorted(list(dict_for_assert.values())), sorted(list(ref_for_assert.values())))
 
-"""
-Some race condition seems to occur when using the tfx Union in a job
-"""
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tfx_union.py
+++ b/tests/test_tfx_union.py
@@ -19,7 +19,7 @@ class TestUnionCreate(unittest.TestCase):
         self.assertTrue(self.w.is_valid)
 
 
-@unittest.skip  # causes the test harness to hang in the all_tests scenario
+#@unittest.skip  # causes the test harness to hang in the all_tests scenario
 class TestUnionRun(unittest.TestCase):
     def setUp(self):
         self.w = gibbon.Workflow('test_union')


### PR DESCRIPTION
Bug fixed. A condition of checking whether a queues was empty or not wrecked the logic of an infinite loop that kept on hanging because of a race condition between queues.